### PR TITLE
Add support for generating completion scripts

### DIFF
--- a/docsrc/completions.rst
+++ b/docsrc/completions.rst
@@ -1,7 +1,9 @@
 Shell completions
 =================
 
-Argparse supports generating shell completion scripts for Bash, Zsh, and Fish.
+Argparse can generate shell completion scripts for
+`Bash <https://www.gnu.org/software/bash/>`_, `Zsh <https://www.zsh.org/>`_, and
+`Fish <https://fishshell.com/>`_.
 The completion scripts support completing options, commands, and argument
 choices.
 
@@ -11,9 +13,9 @@ The Parser methods ``:get_bash_complete()``, ``get_zsh_complete()``, and
 Adding a completion option or command
 -------------------------------------
 
-A ``--completion`` option can be added to the parser using the
+A ``--completion`` option can be added to a parser using the
 ``:add_complete([value])`` method. The optional ``value`` argument is a string
-or table used to configure the option.
+or table used to configure the option (by calling the option with ``value``).
 
 .. code-block:: lua
    :linenos:
@@ -34,18 +36,20 @@ or table used to configure the option.
       --completion {bash,zsh,fish}
                             Output a shell completion script for the specified shell.
 
-A similar ``completion`` command can be added to the parser using the
+A similar ``completion`` command can be added to a parser using the
 ``:add_complete_command([value])`` method.
 
-Activating completions
-----------------------
+Using completions
+-----------------
 
 Bash
 ^^^^
 
 Save the generated completion script at
-``~/.local/share/bash-completion/completions/script.lua`` or add the following
-line to the ``~/.bashrc``:
+``/usr/share/bash-completion/completions/script.lua`` or
+``~/.local/share/bash-completion/completions/script.lua``.
+
+Alternatively, add the following line to the ``~/.bashrc``:
 
 .. code-block:: bash
 
@@ -54,20 +58,20 @@ line to the ``~/.bashrc``:
 Zsh
 ^^^
 
-The completion script should be placed in a directory in the ``$fpath``.  A new
-directory can be added to to the ``$fpath`` by adding e.g.
-``fpath=(~/.zfunc $fpath)`` in the ``~/.zshrc`` before ``compinit``. Save the
-completion script with:
-
-.. code-block:: none
-
-   $ script.lua --completion zsh > ~/.zfunc/_script.lua
+Save the completion script in the ``/usr/share/zsh/site-functions/`` directory
+or any directory in the ``$fpath``. The file name should be an underscore
+followed by the program name. A new directory can be added to to the ``$fpath``
+by adding e.g. ``fpath=(~/.zfunc $fpath)`` in the ``~/.zshrc`` before
+``compinit``.
 
 Fish
 ^^^^
 
-Save the completion script at ``~/.config/fish/completions/script.lua.fish`` or
-add the following line to the file ``~/.config/fish/config.fish``:
+Save the completion script at
+``/usr/share/fish/vendor_completions.d/script.lua.fish`` or
+``~/.config/fish/completions/script.lua.fish``.
+
+Alternatively, add the following line to the file ``~/.config/fish/config.fish``:
 
 .. code-block:: fish
 

--- a/docsrc/completions.rst
+++ b/docsrc/completions.rst
@@ -1,0 +1,74 @@
+Shell completions
+=================
+
+Argparse supports generating shell completion scripts for Bash, Zsh, and Fish.
+The completion scripts support completing options, commands, and argument
+choices.
+
+The Parser methods ``:get_bash_complete()``, ``get_zsh_complete()``, and
+``:get_fish_complete()`` return completion scripts as a string.
+
+Adding a completion option or command
+-------------------------------------
+
+A ``--completion`` option can be added to the parser using the
+``:add_complete([value])`` method. The optional ``value`` argument is a string
+or table used to configure the option.
+
+.. code-block:: lua
+   :linenos:
+
+   local parser = argparse()
+      :add_complete()
+
+.. code-block:: none
+
+   $ lua script.lua -h
+
+.. code-block:: none
+
+   Usage: script.lua [-h] [--completion {bash,zsh,fish}]
+
+   Options:
+      -h, --help            Show this help message and exit.
+      --completion {bash,zsh,fish}
+                            Output a shell completion script for the specified shell.
+
+A similar ``completion`` command can be added to the parser using the
+``:add_complete_command([value])`` method.
+
+Activating completions
+----------------------
+
+Bash
+^^^^
+
+Save the generated completion script at
+``~/.local/share/bash-completion/completions/script.lua`` or add the following
+line to the ``~/.bashrc``:
+
+.. code-block:: bash
+
+   source <(script.lua --completion bash)
+
+Zsh
+^^^
+
+The completion script should be placed in a directory in the ``$fpath``.  A new
+directory can be added to to the ``$fpath`` by adding e.g.
+``fpath=(~/.zfunc $fpath)`` in the ``~/.zshrc`` before ``compinit``. Save the
+completion script with:
+
+.. code-block:: none
+
+   $ script.lua --completion zsh > ~/.zfunc/_script.lua
+
+Fish
+^^^^
+
+Save the completion script at ``~/.config/fish/completions/script.lua.fish`` or
+add the following line to the file ``~/.config/fish/config.fish``:
+
+.. code-block:: fish
+
+   script.lua --completion fish | source

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -13,6 +13,7 @@ Contents:
    defaults
    callbacks
    messages
+   completions
    misc
 
 This is a tutorial for `argparse <https://github.com/mpeterv/argparse>`_, a feature-rich command line parser for Lua.

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -86,7 +86,7 @@ complete -F _comptest -o bashdefault -o default comptest
 
    it("generates correct zsh completion script", function()
       assert.equal([=[
-compdef _comptest comptest
+#compdef comptest
 
 _comptest() {
   local context state state_descr line
@@ -179,6 +179,8 @@ _comptest_admin_cmds() {
   )
   _describe "command" commands
 }
+
+_comptest
 ]=], get_output("completion zsh"))
    end)
 

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -13,8 +13,7 @@ _foo() {
     cmd="foo"
     opts="-h --help"
 
-    if [[ "$cur" = -* ]]
-    then
+    if [[ "$cur" = -* ]]; then
         COMPREPLY=($(compgen -W "$opts" -- "$cur"))
     fi
 }
@@ -41,8 +40,7 @@ _foo() {
             ;;
     esac
 
-    if [[ "$cur" = -* ]]
-    then
+    if [[ "$cur" = -* ]]; then
         COMPREPLY=($(compgen -W "$opts" -- "$cur"))
     fi
 }
@@ -70,8 +68,7 @@ _foo() {
             ;;
     esac
 
-    if [[ "$cur" = -* ]]
-    then
+    if [[ "$cur" = -* ]]; then
         COMPREPLY=($(compgen -W "$opts" -- "$cur"))
     fi
 }
@@ -92,8 +89,7 @@ _foo() {
     cmd="foo"
     opts=""
 
-    for arg in ${COMP_WORDS[@]:1}
-    do
+    for arg in ${COMP_WORDS[@]:1}; do
         case "$arg" in
             install)
                 cmd="install"
@@ -106,11 +102,9 @@ _foo() {
         foo)
             COMPREPLY=($(compgen -W "install" -- "$cur"))
             ;;
-
     esac
 
-    if [[ "$cur" = -* ]]
-    then
+    if [[ "$cur" = -* ]]; then
         COMPREPLY=($(compgen -W "$opts" -- "$cur"))
     fi
 }
@@ -132,8 +126,7 @@ _foo() {
     cmd="foo"
     opts=""
 
-    for arg in ${COMP_WORDS[@]:1}
-    do
+    for arg in ${COMP_WORDS[@]:1}; do
         case "$arg" in
             install)
                 cmd="install"
@@ -151,8 +144,7 @@ _foo() {
             ;;
     esac
 
-    if [[ "$cur" = -* ]]
-    then
+    if [[ "$cur" = -* ]]; then
         COMPREPLY=($(compgen -W "$opts" -- "$cur"))
     fi
 }
@@ -174,12 +166,8 @@ _foo() {
     cmd="foo"
     opts=""
 
-    for arg in ${COMP_WORDS[@]:1}
-    do
+    for arg in ${COMP_WORDS[@]:1}; do
         case "$arg" in
-            help)
-                break
-                ;;
             install)
                 cmd="install"
                 break
@@ -191,11 +179,9 @@ _foo() {
         foo)
             COMPREPLY=($(compgen -W "help install" -- "$cur"))
             ;;
-
     esac
 
-    if [[ "$cur" = -* ]]
-    then
+    if [[ "$cur" = -* ]]; then
         COMPREPLY=($(compgen -W "$opts" -- "$cur"))
     fi
 }

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -7,6 +7,7 @@ describe("tests related to generation of shell completion scripts", function()
          local parser = Parser "foo"
          assert.equal([=[
 _foo() {
+    local IFS=$' \t\n'
     local cur prev cmd opts arg
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -28,6 +29,7 @@ complete -F _foo -o bashdefault -o default foo
          parser:option "--bar"
          assert.equal([=[
 _foo() {
+    local IFS=$' \t\n'
     local cur prev cmd opts arg
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -57,6 +59,7 @@ complete -F _foo -o bashdefault -o default foo
             :choices {"short", "medium", "full"}
          assert.equal([=[
 _foo() {
+    local IFS=$' \t\n'
     local cur prev cmd opts arg
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -86,6 +89,7 @@ complete -F _foo -o bashdefault -o default foo
             :add_help(false)
          assert.equal([=[
 _foo() {
+    local IFS=$' \t\n'
     local cur prev cmd opts arg
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -124,6 +128,7 @@ complete -F _foo -o bashdefault -o default foo
          install:flag "-v --verbose"
          assert.equal([=[
 _foo() {
+    local IFS=$' \t\n'
     local cur prev cmd opts arg
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -165,6 +170,7 @@ complete -F _foo -o bashdefault -o default foo
             :add_help(false)
          assert.equal([=[
 _foo() {
+    local IFS=$' \t\n'
     local cur prev cmd opts arg
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -1,0 +1,81 @@
+local Parser = require "argparse"
+getmetatable(Parser()).error = function(_, msg) error(msg) end
+
+describe("tests related to generation of shell completion scripts", function()
+   describe("fish completion scripts", function()
+      it("generates correct completions for help flag", function()
+         local parser = Parser "foo"
+         assert.equal([[
+complete -c foo -s h -l help -d 'Show this help message and exit']], parser:get_fish_complete())
+      end)
+
+      it("generates correct completions for options with required argument", function()
+         local parser = Parser "foo"
+            :add_help(false)
+         parser:option "--bar"
+         assert.equal([[
+complete -c foo -l bar -r]], parser:get_fish_complete())
+      end)
+
+      it("generates correct completions for options with argument choices", function()
+         local parser = Parser "foo"
+            :add_help(false)
+         parser:option "--format"
+            :choices {"short", "medium", "full"}
+         assert.equal([[
+complete -c foo -l format -xa 'short medium full']], parser:get_fish_complete())
+      end)
+
+      it("generates correct completions for commands", function()
+         local parser = Parser "foo"
+            :add_help(false)
+         parser:command "install"
+            :add_help(false)
+            :description "Install a rock."
+         assert.equal([[
+complete -c foo -n '__fish_use_subcommand' -xa 'install' -d 'Install a rock']], parser:get_fish_complete())
+      end)
+
+      it("generates correct completions for command options", function()
+         local parser = Parser "foo"
+            :add_help(false)
+         local install = parser:command "install"
+            :add_help(false)
+         install:flag "-v --verbose"
+         assert.equal([[
+complete -c foo -n '__fish_use_subcommand' -xa 'install'
+complete -c foo -n '__fish_seen_subcommand_from install' -s v -l verbose]], parser:get_fish_complete())
+      end)
+
+      it("generates completions for help command argument", function()
+         local parser = Parser "foo"
+            :add_help(false)
+            :add_help_command {add_help = false}
+         parser:command "install"
+            :add_help(false)
+         assert.equal([[
+complete -c foo -n '__fish_seen_subcommand_from help' -xa 'help'
+complete -c foo -n '__fish_seen_subcommand_from help' -xa 'install'
+complete -c foo -n '__fish_use_subcommand' -xa 'help' -d 'Show help for commands'
+complete -c foo -n '__fish_use_subcommand' -xa 'install']], parser:get_fish_complete())
+      end)
+
+      it("uses fist sentence of descriptions", function()
+         local parser = Parser "foo"
+            :add_help(false)
+         parser:option "--bar"
+            :description "A description with a .period. Another sentence."
+         assert.equal([[
+complete -c foo -l bar -r -d 'A description with a .period']], parser:get_fish_complete())
+      end)
+
+      it("escapes backslashes and single quotes in descriptions", function()
+         local parser = Parser "foo"
+            :add_help(false)
+         parser:option "--bar"
+            :description "A description with illegal \\' characters."
+         assert.equal([[
+complete -c foo -l bar -r -d 'A description with illegal \\\' characters']], parser:get_fish_complete())
+      end)
+   end)
+end)

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -96,7 +96,7 @@ _comptest() {
     {-h,--help}"[Show this help message and exit]" \
     "--completion[Output a shell completion script for the specified shell]: :(bash zsh fish)" \
     "*"{-v,--verbose}"[Set the verbosity level]" \
-    {-f,--files}"[A description with illegal \' characters]:*: :_files" \
+    {-f,--files}"[A description with illegal \"' characters]:*: :_files" \
     ": :_comptest_cmds" \
     "*:: :->args" \
     && return 0
@@ -193,7 +193,7 @@ complete -c comptest -n '__fish_use_subcommand' -xa 'admin' -d 'Rock server admi
 complete -c comptest -s h -l help -d 'Show this help message and exit'
 complete -c comptest -l completion -xa 'bash zsh fish' -d 'Output a shell completion script for the specified shell'
 complete -c comptest -s v -l verbose -d 'Set the verbosity level'
-complete -c comptest -s f -l files -r -d 'A description with illegal \\\' characters'
+complete -c comptest -s f -l files -r -d 'A description with illegal "\' characters'
 
 complete -c comptest -n '__fish_seen_subcommand_from help' -xa 'help completion install i admin'
 complete -c comptest -n '__fish_seen_subcommand_from help' -s h -l help -d 'Show this help message and exit'

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -260,8 +260,7 @@ complete -c foo -n '__fish_seen_subcommand_from install' -s v -l verbose
             :add_help(false)
          assert.equal([[
 complete -c foo -n '__fish_use_subcommand' -xa 'help' -d 'Show help for commands'
-complete -c foo -n '__fish_seen_subcommand_from help' -xa 'help'
-complete -c foo -n '__fish_seen_subcommand_from help' -xa 'install'
+complete -c foo -n '__fish_seen_subcommand_from help' -xa 'help install'
 complete -c foo -n '__fish_use_subcommand' -xa 'install'
 ]], parser:get_fish_complete())
       end)

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -259,9 +259,9 @@ complete -c foo -n '__fish_seen_subcommand_from install' -s v -l verbose
          parser:command "install"
             :add_help(false)
          assert.equal([[
+complete -c foo -n '__fish_use_subcommand' -xa 'help' -d 'Show help for commands'
 complete -c foo -n '__fish_seen_subcommand_from help' -xa 'help'
 complete -c foo -n '__fish_seen_subcommand_from help' -xa 'install'
-complete -c foo -n '__fish_use_subcommand' -xa 'help' -d 'Show help for commands'
 complete -c foo -n '__fish_use_subcommand' -xa 'install'
 ]], parser:get_fish_complete())
       end)

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -23,15 +23,15 @@ _comptest() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     cmd="comptest"
-    opts="-h --help -f --files --direction"
+    opts="-h --help --completion -v --verbose -f --files"
 
     case "$prev" in
-        -f|--files)
-            COMPREPLY=($(compgen -f "$cur"))
+        --completion)
+            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
             return 0
             ;;
-        --direction)
-            COMPREPLY=($(compgen -W "north south east west" -- "$cur"))
+        -f|--files)
+            COMPREPLY=($(compgen -f "$cur"))
             return 0
             ;;
     esac
@@ -66,13 +66,9 @@ _comptest() {
                     COMPREPLY=($(compgen -W "all one order none" -- "$cur"))
                     return 0
                     ;;
-                --pair)
-                    COMPREPLY=($(compgen -f "$cur"))
-                    return 0
-                    ;;
             esac
 
-            opts="$opts -h --help --deps-mode --no-doc --pair"
+            opts="$opts -h --help --deps-mode --no-doc"
             ;;
         admin)
             opts="$opts -h --help"
@@ -98,8 +94,9 @@ _comptest() {
 
   _arguments -s -S \
     {-h,--help}"[Show this help message and exit]" \
+    "--completion[Output a shell completion script for the specified shell]: :(bash zsh fish)" \
+    "*"{-v,--verbose}"[Set the verbosity level]" \
     {-f,--files}"[A description with illegal \' characters]:*: :_files" \
-    "--direction[The direction to go in]: :(north south east west)" \
     ": :_comptest_cmds" \
     "*:: :->args" \
     && return 0
@@ -124,7 +121,6 @@ _comptest() {
         {-h,--help}"[Show this help message and exit]" \
         "--deps-mode: :(all one order none)" \
         "--no-doc[Install without documentation]" \
-        "*--pair[A pair of files]: :_files" \
         && return 0
       ;;
 
@@ -170,7 +166,7 @@ _comptest_cmds() {
     "help:Show help for commands"
     "completion:Output a shell completion script"
     {install,i}":Install a rock"
-    "admin"
+    "admin:Rock server administration interface"
   )
   _describe "command" commands
 }
@@ -193,10 +189,11 @@ complete -c comptest -n '__fish_use_subcommand' -xa 'help' -d 'Show help for com
 complete -c comptest -n '__fish_use_subcommand' -xa 'completion' -d 'Output a shell completion script'
 complete -c comptest -n '__fish_use_subcommand' -xa 'install' -d 'Install a rock'
 complete -c comptest -n '__fish_use_subcommand' -xa 'i' -d 'Install a rock'
-complete -c comptest -n '__fish_use_subcommand' -xa 'admin'
+complete -c comptest -n '__fish_use_subcommand' -xa 'admin' -d 'Rock server administration interface'
 complete -c comptest -s h -l help -d 'Show this help message and exit'
+complete -c comptest -l completion -xa 'bash zsh fish' -d 'Output a shell completion script for the specified shell'
+complete -c comptest -s v -l verbose -d 'Set the verbosity level'
 complete -c comptest -s f -l files -r -d 'A description with illegal \\\' characters'
-complete -c comptest -l direction -xa 'north south east west' -d 'The direction to go in'
 
 complete -c comptest -n '__fish_seen_subcommand_from help' -xa 'help completion install i admin'
 complete -c comptest -n '__fish_seen_subcommand_from help' -s h -l help -d 'Show this help message and exit'
@@ -206,7 +203,6 @@ complete -c comptest -n '__fish_seen_subcommand_from completion' -s h -l help -d
 complete -c comptest -n '__fish_seen_subcommand_from install i' -s h -l help -d 'Show this help message and exit'
 complete -c comptest -n '__fish_seen_subcommand_from install i' -l deps-mode -xa 'all one order none'
 complete -c comptest -n '__fish_seen_subcommand_from install i' -l no-doc -d 'Install without documentation'
-complete -c comptest -n '__fish_seen_subcommand_from install i' -l pair -r -d 'A pair of files'
 
 complete -c comptest -n '__fish_use_subcommand' -xa 'help' -d 'Show help for commands'
 complete -c comptest -n '__fish_use_subcommand' -xa 'add' -d 'Add a rock to a server'

--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -18,7 +18,8 @@ _foo() {
     fi
 }
 
-complete -F _foo -o bashdefault -o default foo]=], parser:get_bash_complete())
+complete -F _foo -o bashdefault -o default foo
+]=], parser:get_bash_complete())
       end)
 
       it("generates correct completions for options with required argument", function()
@@ -45,7 +46,8 @@ _foo() {
     fi
 }
 
-complete -F _foo -o bashdefault -o default foo]=], parser:get_bash_complete())
+complete -F _foo -o bashdefault -o default foo
+]=], parser:get_bash_complete())
       end)
 
       it("generates correct completions for options with argument choices", function()
@@ -73,7 +75,8 @@ _foo() {
     fi
 }
 
-complete -F _foo -o bashdefault -o default foo]=], parser:get_bash_complete())
+complete -F _foo -o bashdefault -o default foo
+]=], parser:get_bash_complete())
       end)
 
       it("generates correct completions for commands", function()
@@ -109,7 +112,8 @@ _foo() {
     fi
 }
 
-complete -F _foo -o bashdefault -o default foo]=], parser:get_bash_complete())
+complete -F _foo -o bashdefault -o default foo
+]=], parser:get_bash_complete())
       end)
 
       it("generates correct completions for command options", function()
@@ -149,7 +153,8 @@ _foo() {
     fi
 }
 
-complete -F _foo -o bashdefault -o default foo]=], parser:get_bash_complete())
+complete -F _foo -o bashdefault -o default foo
+]=], parser:get_bash_complete())
       end)
 
       it("generates completions for help command argument", function()
@@ -186,7 +191,8 @@ _foo() {
     fi
 }
 
-complete -F _foo -o bashdefault -o default foo]=], parser:get_bash_complete())
+complete -F _foo -o bashdefault -o default foo
+]=], parser:get_bash_complete())
       end)
    end)
 
@@ -194,7 +200,8 @@ complete -F _foo -o bashdefault -o default foo]=], parser:get_bash_complete())
       it("generates correct completions for help flag", function()
          local parser = Parser "foo"
          assert.equal([[
-complete -c foo -s h -l help -d 'Show this help message and exit']], parser:get_fish_complete())
+complete -c foo -s h -l help -d 'Show this help message and exit'
+]], parser:get_fish_complete())
       end)
 
       it("generates correct completions for options with required argument", function()
@@ -202,7 +209,8 @@ complete -c foo -s h -l help -d 'Show this help message and exit']], parser:get_
             :add_help(false)
          parser:option "--bar"
          assert.equal([[
-complete -c foo -l bar -r]], parser:get_fish_complete())
+complete -c foo -l bar -r
+]], parser:get_fish_complete())
       end)
 
       it("generates correct completions for options with argument choices", function()
@@ -211,7 +219,8 @@ complete -c foo -l bar -r]], parser:get_fish_complete())
          parser:option "--format"
             :choices {"short", "medium", "full"}
          assert.equal([[
-complete -c foo -l format -xa 'short medium full']], parser:get_fish_complete())
+complete -c foo -l format -xa 'short medium full'
+]], parser:get_fish_complete())
       end)
 
       it("generates correct completions for commands", function()
@@ -221,7 +230,8 @@ complete -c foo -l format -xa 'short medium full']], parser:get_fish_complete())
             :add_help(false)
             :description "Install a rock."
          assert.equal([[
-complete -c foo -n '__fish_use_subcommand' -xa 'install' -d 'Install a rock']], parser:get_fish_complete())
+complete -c foo -n '__fish_use_subcommand' -xa 'install' -d 'Install a rock'
+]], parser:get_fish_complete())
       end)
 
       it("generates correct completions for command options", function()
@@ -232,7 +242,8 @@ complete -c foo -n '__fish_use_subcommand' -xa 'install' -d 'Install a rock']], 
          install:flag "-v --verbose"
          assert.equal([[
 complete -c foo -n '__fish_use_subcommand' -xa 'install'
-complete -c foo -n '__fish_seen_subcommand_from install' -s v -l verbose]], parser:get_fish_complete())
+complete -c foo -n '__fish_seen_subcommand_from install' -s v -l verbose
+]], parser:get_fish_complete())
       end)
 
       it("generates completions for help command argument", function()
@@ -245,7 +256,8 @@ complete -c foo -n '__fish_seen_subcommand_from install' -s v -l verbose]], pars
 complete -c foo -n '__fish_seen_subcommand_from help' -xa 'help'
 complete -c foo -n '__fish_seen_subcommand_from help' -xa 'install'
 complete -c foo -n '__fish_use_subcommand' -xa 'help' -d 'Show help for commands'
-complete -c foo -n '__fish_use_subcommand' -xa 'install']], parser:get_fish_complete())
+complete -c foo -n '__fish_use_subcommand' -xa 'install'
+]], parser:get_fish_complete())
       end)
 
       it("uses fist sentence of descriptions", function()
@@ -254,7 +266,8 @@ complete -c foo -n '__fish_use_subcommand' -xa 'install']], parser:get_fish_comp
          parser:option "--bar"
             :description "A description with a .period. Another sentence."
          assert.equal([[
-complete -c foo -l bar -r -d 'A description with a .period']], parser:get_fish_complete())
+complete -c foo -l bar -r -d 'A description with a .period'
+]], parser:get_fish_complete())
       end)
 
       it("escapes backslashes and single quotes in descriptions", function()
@@ -263,7 +276,8 @@ complete -c foo -l bar -r -d 'A description with a .period']], parser:get_fish_c
          parser:option "--bar"
             :description "A description with illegal \\' characters."
          assert.equal([[
-complete -c foo -l bar -r -d 'A description with illegal \\\' characters']], parser:get_fish_complete())
+complete -c foo -l bar -r -d 'A description with illegal \\\' characters'
+]], parser:get_fish_complete())
       end)
    end)
 end)

--- a/spec/comptest
+++ b/spec/comptest
@@ -5,14 +5,15 @@ local argparse = require "argparse"
 local parser = argparse()
    :add_help_command()
    :add_complete_command()
+   :add_complete()
+
+parser:flag "-v --verbose"
+   :description "Set the verbosity level."
+   :count "*"
 
 parser:option "-f --files"
    :description "A description with illegal \\' characters."
    :args "+"
-
-parser:option "--direction"
-   :description "The direction to go in."
-   :choices {"north", "south", "east", "west"}
 
 local install = parser:command "install i"
    :description "Install a rock."
@@ -23,12 +24,8 @@ install:option "--deps-mode"
 install:flag "--no-doc"
    :description "Install without documentation."
 
-install:option "--pair"
-   :description "A pair of files."
-   :args "2"
-   :count "*"
-
 local admin = parser:command "admin"
+   :description "Rock server administration interface."
    :add_help_command()
 
 local admin_add = admin:command "add"

--- a/spec/comptest
+++ b/spec/comptest
@@ -1,0 +1,42 @@
+#!/usr/bin/env lua
+
+local argparse = require "argparse"
+
+local parser = argparse "comptest"
+   :add_help_command()
+   :add_complete_command()
+
+parser:option "-f --files"
+   :description "A description with illegal \\' characters."
+   :args "+"
+
+parser:option "--direction"
+   :description "The direction to go in."
+   :choices {"north", "south", "east", "west"}
+
+local install = parser:command "install i"
+   :description "Install a rock."
+
+install:option "--deps-mode"
+   :choices {"all", "one", "order", "none"}
+
+install:flag "--no-doc"
+   :description "Install without documentation."
+
+install:option "--pair"
+   :description "A pair of files."
+   :args "2"
+   :count "*"
+
+local admin = parser:command "admin"
+   :add_help_command()
+
+local admin_add = admin:command "add"
+   :description "Add a rock to a server."
+admin_add:argument "rock"
+
+local admin_remove = admin:command "remove"
+   :description "Remove a rock from  a server."
+admin_remove:argument "rock"
+
+parser:parse()

--- a/spec/comptest
+++ b/spec/comptest
@@ -12,7 +12,7 @@ parser:flag "-v --verbose"
    :count "*"
 
 parser:option "-f --files"
-   :description "A description with illegal \\' characters."
+   :description "A description with illegal \"' characters."
    :args "+"
 
 local install = parser:command "install i"

--- a/spec/comptest
+++ b/spec/comptest
@@ -2,7 +2,7 @@
 
 local argparse = require "argparse"
 
-local parser = argparse "comptest"
+local parser = argparse()
    :add_help_command()
    :add_complete_command()
 

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1233,7 +1233,10 @@ end
 function Parser:get_zsh_complete()
    local buf = {("compdef _%s %s\n"):format(self._name, self._name)}
    table.insert(buf, ("_%s() {"):format(self._name))
-   table.insert(buf, "    _arguments -s -S -C \\")
+   table.insert(buf, "  typeset -A opt_args")
+   table.insert(buf, "  local context state line")
+   table.insert(buf, "  local ret=1\n")
+   table.insert(buf, "  _arguments -s -S -C \\")
 
    for _, option in ipairs(self._options) do
       local line = {}
@@ -1249,9 +1252,11 @@ function Parser:get_zsh_complete()
          end
          table.insert(line, '"')
       end
-      table.insert(buf, (" "):rep(8) .. table.concat(line) .. " \\")
+      table.insert(buf, (" "):rep(4) .. table.concat(line) .. " \\")
    end
 
+   table.insert(buf, "    && ret=0\n")
+   table.insert(buf, "  return ret")
    table.insert(buf, "}")
 
    return table.concat(buf, "\n") .. "\n"

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -204,9 +204,6 @@ local add_help = {"add_help", function(self, value)
 
    if self._help_option_idx then
       table.remove(self._options, self._help_option_idx)
-      if self._complete_option_idx and self._complete_option_idx > self._help_option_idx then
-         self._complete_option_idx = self._complete_option_idx - 1
-      end
       self._help_option_idx = nil
    end
 
@@ -231,35 +228,23 @@ local add_help = {"add_help", function(self, value)
 end}
 
 local add_complete = {"add_complete", function(self, value)
-   typecheck("add_complete", {"boolean", "string", "table"}, value)
+   typecheck("add_complete", {"nil", "string", "table"}, value)
 
-   if self._complete_option_idx then
-      table.remove(self._options, self._complete_option_idx)
-      if self._help_option_idx and self._help_option_idx > self._complete_option_idx then
-         self._help_option_idx = self._help_option_idx - 1
-      end
-      self._complete_option_idx = nil
-   end
+   local complete = self:option()
+      :description "Output a shell completion script for the specified shell."
+      :args(1)
+      :choices {"bash", "zsh", "fish"}
+      :action(function(_, _, shell)
+         print(self["get_" .. shell .. "_complete"](self))
+         os.exit(0)
+      end)
 
    if value then
-      local complete = self:option()
-         :description "Output a shell completion script for the specified shell."
-         :args(1)
-         :choices {"bash", "zsh", "fish"}
-         :action(function(_, _, shell)
-            print(self["get_" .. shell .. "_complete"](self))
-            os.exit(0)
-         end)
+      complete = complete(value)
+   end
 
-      if value ~= true then
-         complete = complete(value)
-      end
-
-      if not complete._name then
-         complete "--completion"
-      end
-
-      self._complete_option_idx = #self._options
+   if not complete._name then
+      complete "--completion"
    end
 end}
 

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -247,7 +247,7 @@ local add_complete = {"add_complete", function(self, value)
          :args(1)
          :choices {"bash", "zsh", "fish"}
          :action(function(_, _, shell)
-            self["get_" .. shell .. "_complete"](self)
+            print(self["get_" .. shell .. "_complete"](self))
             os.exit(0)
          end)
 
@@ -1201,7 +1201,7 @@ function Parser:get_fish_complete()
 
    self:_fish_complete_help(lines, prefix)
 
-   io.write(table.concat(lines, "\n"), "\n")
+   return table.concat(lines, "\n")
 end
 
 local function get_tip(context, wrong_name)

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1398,6 +1398,7 @@ function Parser:get_zsh_complete()
    end
    self:_zsh_arguments(buf, self._name, 2)
    self:_zsh_complete_help(buf, cmds_buf, self._name, 2)
+   table.insert(buf, "\n  return 1")
    table.insert(buf, "}")
 
    local result = table.concat(buf, "\n")

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1224,7 +1224,7 @@ function Parser:_bash_get_cmd(buf)
    for _, command in ipairs(self._commands) do
       if not command._is_help_command then
          table.insert(cmds, (" "):rep(12) .. table.concat(command._aliases, "|") .. ")")
-         table.insert(cmds, (" "):rep(16) .. 'cmd="' .. command._aliases[1] .. '"')
+         table.insert(cmds, (" "):rep(16) .. 'cmd="' .. command._name .. '"')
          table.insert(cmds, (" "):rep(16) .. "break")
          table.insert(cmds, (" "):rep(16) .. ";;")
       end
@@ -1243,7 +1243,7 @@ function Parser:_bash_cmd_completions(buf)
    local subcmds = {}
    for _, command in ipairs(self._commands) do
       if #command._options > 0 and not command._is_help_command then
-         table.insert(subcmds, (" "):rep(8) .. command._aliases[1] .. ")")
+         table.insert(subcmds, (" "):rep(8) .. command._name .. ")")
          command:_bash_option_args(subcmds, 12)
          table.insert(subcmds, (" "):rep(12) .. 'opts="$opts ' .. command:_get_options() .. '"')
          table.insert(subcmds, (" "):rep(12) .. ";;")
@@ -1305,7 +1305,7 @@ function Parser:_zsh_arguments(buf, cmd_name, indent)
          if option._maxcount > 1 then
             table.insert(line, "*")
          end
-         table.insert(line, option._aliases[1])
+         table.insert(line, option._name)
       end
       if option._description then
          table.insert(line, "[" .. get_short_description(option) .. "]")
@@ -1360,7 +1360,7 @@ function Parser:_zsh_cmds(buf, cmd_name)
       if #command._aliases > 1 then
          table.insert(line, "{" .. table.concat(command._aliases, ",") .. '}"')
       else
-         table.insert(line, '"' .. command._aliases[1])
+         table.insert(line, '"' .. command._name)
       end
       if command._description then
          table.insert(line, ":" .. get_short_description(command))
@@ -1380,7 +1380,7 @@ function Parser:_zsh_complete_help(buf, cmds_buf, cmd_name, indent)
    table.insert(buf, "\n" .. (" "):rep(indent) .. "case $words[1] in")
 
    for _, command in ipairs(self._commands) do
-      local name = cmd_name .. "_" .. command._aliases[1]
+      local name = cmd_name .. "_" .. command._name
       table.insert(buf, (" "):rep(indent + 2) .. table.concat(command._aliases, "|") .. ")")
       command:_zsh_arguments(buf, name, indent + 4)
       command:_zsh_complete_help(buf, cmds_buf, name, indent + 4)

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1110,6 +1110,33 @@ function Parser:add_complete(value)
    return self
 end
 
+function Parser:add_complete_command(value)
+   if value then
+      assert(type(value) == "string" or type(value) == "table",
+         ("bad argument #1 to 'add_complete_command' (string or table expected, got %s)"):format(type(value)))
+   end
+
+   local complete = self:command()
+      :description "Output a shell completion script."
+   complete:argument "shell"
+      :description "The shell to output a completion script for."
+      :choices {"bash", "zsh", "fish"}
+      :action(function(_, _, shell)
+         io.write(self["get_" .. shell .. "_complete"](self))
+         os.exit(0)
+      end)
+
+   if value then
+      complete = complete(value)
+   end
+
+   if not complete._name then
+      complete "completion"
+   end
+
+   return self
+end
+
 local function get_short_description(element)
    local short = element:_get_description():match("^(.-)%.%s")
    return short or element:_get_description():match("^(.-)%.?$")

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1409,7 +1409,7 @@ end
 function Parser:get_zsh_complete()
    self._basename = base_name(self._name)
    assert(self:_is_shell_safe())
-   local buf = {("compdef _%s %s\n"):format(self._basename, self._basename)}
+   local buf = {("#compdef %s\n"):format(self._basename)}
    local cmds_buf = {}
    table.insert(buf, "_" .. self._basename .. "() {")
    if #self._commands > 0 then
@@ -1425,7 +1425,7 @@ function Parser:get_zsh_complete()
    if #cmds_buf > 0 then
       result = result .. "\n" .. table.concat(cmds_buf, "\n")
    end
-   return result .. "\n"
+   return result .. "\n\n_" .. self._basename .. "\n"
 end
 
 local function fish_escape(string)

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1308,9 +1308,12 @@ function Parser:_zsh_arguments(buf, cmd_name, indent)
       if option._description then
          table.insert(line, "[" .. get_short_description(option) .. "]")
       end
+      if option._maxargs == math.huge then
+         table.insert(line, ":*")
+      end
       if option._choices then
          table.insert(line, ": :(" .. table.concat(option._choices, " ") .. ")")
-      elseif option._minargs > 0 then
+      elseif option._maxargs > 0 then
          table.insert(line, ": :_files")
       end
       table.insert(line, '"')

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -227,27 +227,6 @@ local add_help = {"add_help", function(self, value)
    end
 end}
 
-local add_complete = {"add_complete", function(self, value)
-   typecheck("add_complete", {"nil", "string", "table"}, value)
-
-   local complete = self:option()
-      :description "Output a shell completion script for the specified shell."
-      :args(1)
-      :choices {"bash", "zsh", "fish"}
-      :action(function(_, _, shell)
-         print(self["get_" .. shell .. "_complete"](self))
-         os.exit(0)
-      end)
-
-   if value then
-      complete = complete(value)
-   end
-
-   if not complete._name then
-      complete "--completion"
-   end
-end}
-
 local Parser = class({
    _arguments = {},
    _options = {},
@@ -273,8 +252,7 @@ local Parser = class({
    typechecked("help_usage_margin", "number"),
    typechecked("help_description_margin", "number"),
    typechecked("help_max_width", "number"),
-   add_help,
-   add_complete
+   add_help
 })
 
 local Command = class({
@@ -1100,6 +1078,32 @@ function Parser:add_help_command(value)
 
    if not help._name then
       help "help"
+   end
+
+   return self
+end
+
+function Parser:add_complete(value)
+   if value then
+      assert(type(value) == "string" or type(value) == "table",
+         ("bad argument #1 to 'add_complete' (string or table expected, got %s)"):format(type(value)))
+   end
+
+   local complete = self:option()
+      :description "Output a shell completion script for the specified shell."
+      :args(1)
+      :choices {"bash", "zsh", "fish"}
+      :action(function(_, _, shell)
+         print(self["get_" .. shell .. "_complete"](self))
+         os.exit(0)
+      end)
+
+   if value then
+      complete = complete(value)
+   end
+
+   if not complete._name then
+      complete "--completion"
    end
 
    return self

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1120,6 +1120,11 @@ function Parser:add_help_command(value)
    return self
 end
 
+local function get_short_description(element)
+   local short = element._description:match("^(.-)%.%s")
+   return short or element._description:match("^(.-)%.?$")
+end
+
 function Parser:get_bash_complete() print "not yet implemented" end
 
 function Parser:get_zsh_complete() print "not yet implemented" end
@@ -1131,8 +1136,13 @@ end
 function Parser:_fish_complete_help(lines, prefix)
    for _, command in ipairs(self._commands) do
       for _, alias in ipairs(command._aliases) do
-         local line = ("%s -n '__fish_use_subcommand' -xa '%s' -d '%s'")
-            :format(prefix, alias, fish_escape(command._description))
+         local line = ("%s -n '__fish_use_subcommand' -xa '%s'"):format(prefix, alias)
+
+         if command._description then
+            local description = fish_escape(get_short_description(command))
+            line = ("%s -d '%s'"):format(line, description)
+         end
+
          table.insert(lines, line)
       end
    end
@@ -1162,7 +1172,7 @@ function Parser:_fish_complete_help(lines, prefix)
       end
 
       if option._description then
-         local description = ("-d '%s'"):format(fish_escape(option._description))
+         local description = ("-d '%s'"):format(fish_escape(get_short_description(option)))
          table.insert(parts, description)
       end
 

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1080,6 +1080,7 @@ function Parser:add_help_command(value)
       help "help"
    end
 
+   self._help_command = help
    return self
 end
 
@@ -1162,8 +1163,8 @@ end
 
 function Parser:_bash_get_cmd(buf)
    local cmds = {}
-   for idx, command in ipairs(self._commands) do
-      if idx ~= self._help_command_idx then
+   for _, command in ipairs(self._commands) do
+      if command ~= self._help_command then
          table.insert(cmds, (" "):rep(12) .. ("%s)"):format(table.concat(command._aliases, "|")))
          table.insert(cmds, (" "):rep(16) .. ('cmd="%s"'):format(command._aliases[1]))
          table.insert(cmds, (" "):rep(16) .. "break")
@@ -1182,8 +1183,8 @@ end
 
 function Parser:_bash_cmd_completions(buf)
    local subcmds = {}
-   for idx, command in ipairs(self._commands) do
-      if #command._options > 0 and idx ~= self._help_command_idx then
+   for _, command in ipairs(self._commands) do
+      if #command._options > 0 and command ~= self._help_command then
          table.insert(subcmds, (" "):rep(8) .. command._aliases[1] .. ")")
          command:_bash_option_args(subcmds, 12)
          table.insert(subcmds, (" "):rep(12) .. ('opts="$opts %s"'):format(get_options(command)))
@@ -1289,9 +1290,8 @@ function Parser:get_fish_complete()
    local lines = {}
    local prefix = ("complete -c %s"):format(self._name)
 
-   if self._help_command_idx then
-      local help_cmd = self._commands[self._help_command_idx]
-      local help_aliases = table.concat(help_cmd._aliases, " ")
+   if self._help_command then
+      local help_aliases = table.concat(self._help_command._aliases, " ")
 
       for _, command in ipairs(self._commands) do
          local line = ("%s -n '__fish_seen_subcommand_from %s' -xa '%s'")

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1230,7 +1230,32 @@ complete -F _%s -o bashdefault -o default %s
    return table.concat(buf, "\n")
 end
 
-function Parser:get_zsh_complete() print "not yet implemented" end
+function Parser:get_zsh_complete()
+   local buf = {("compdef _%s %s\n"):format(self._name, self._name)}
+   table.insert(buf, ("_%s() {"):format(self._name))
+   table.insert(buf, "    _arguments -s -S -C \\")
+
+   for _, option in ipairs(self._options) do
+      local line = {}
+      if #option._aliases > 1 then
+         table.insert(line, ("{%s}"):format(table.concat(option._aliases, ",")))
+         if option._description then
+            table.insert(line, ('"[%s]"'):format(get_short_description(option)))
+         end
+      else
+         table.insert(line, '"' .. option._aliases[1])
+         if option._description then
+            table.insert(line, ("[%s]"):format(get_short_description(option)))
+         end
+         table.insert(line, '"')
+      end
+      table.insert(buf, (" "):rep(8) .. table.concat(line) .. " \\")
+   end
+
+   table.insert(buf, "}")
+
+   return table.concat(buf, "\n") .. "\n"
+end
 
 local function fish_escape(string)
    return string:gsub("[\\']", "\\%0")

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1095,7 +1095,7 @@ function Parser:add_complete(value)
       :args(1)
       :choices {"bash", "zsh", "fish"}
       :action(function(_, _, shell)
-         print(self["get_" .. shell .. "_complete"](self))
+         io.write(self["get_" .. shell .. "_complete"](self))
          os.exit(0)
       end)
 
@@ -1224,7 +1224,8 @@ _%s() {
     fi
 }
 
-complete -F _%s -o bashdefault -o default %s]=]):format(self._name, self._name))
+complete -F _%s -o bashdefault -o default %s
+]=]):format(self._name, self._name))
 
    return table.concat(buf, "\n")
 end
@@ -1302,7 +1303,7 @@ function Parser:get_fish_complete()
 
    self:_fish_complete_help(lines, prefix)
 
-   return table.concat(lines, "\n")
+   return table.concat(lines, "\n") .. "\n"
 end
 
 local function get_tip(context, wrong_name)

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1110,6 +1110,15 @@ function Parser:_is_shell_safe()
          end
       end
    end
+   for _, argument in ipairs(self._arguments) do
+      if argument._choices then
+         for _, choice in ipairs(argument._choices) do
+            if choice:find("[%s'\"]") then
+               return false
+            end
+         end
+      end
+   end
    for _, command in ipairs(self._commands) do
       if not command:_is_shell_safe() then
          return false
@@ -1314,7 +1323,8 @@ function Parser:_zsh_arguments(buf, cmd_name, indent)
          table.insert(line, option._name)
       end
       if option._description then
-         table.insert(line, "[" .. get_short_description(option) .. "]")
+         local description = get_short_description(option):gsub('["%]:]', "\\%0")
+         table.insert(line, "[" .. description .. "]")
       end
       if option._maxargs == math.huge then
          table.insert(line, ":*")
@@ -1369,7 +1379,7 @@ function Parser:_zsh_cmds(buf, cmd_name)
          table.insert(line, '"' .. command._name)
       end
       if command._description then
-         table.insert(line, ":" .. get_short_description(command))
+         table.insert(line, ":" .. get_short_description(command):gsub('["]', "\\%0"))
       end
       table.insert(buf, "    " .. table.concat(line) .. '"')
    end

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1205,6 +1205,7 @@ end
 function Parser:get_bash_complete()
    local buf = {([[
 _%s() {
+    local IFS=$' \t\n'
     local cur prev cmd opts arg
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1411,6 +1411,8 @@ local function fish_escape(string)
 end
 
 function Parser:_fish_complete_help(buf, prefix)
+   table.insert(buf, "")
+
    for _, command in ipairs(self._commands) do
       for _, alias in ipairs(command._aliases) do
          local line = ("%s -n '__fish_use_subcommand' -xa '%s'"):format(prefix, alias)
@@ -1420,11 +1422,12 @@ function Parser:_fish_complete_help(buf, prefix)
          table.insert(buf, line)
       end
 
-      if command._is_help_command then
-         local line = ("%s -n '__fish_seen_subcommand_from %s' -xa '%s'")
-            :format(prefix, table.concat(command._aliases, " "), self:_get_commands())
-         table.insert(buf, line)
-      end
+   end
+
+   if self._is_help_command then
+      local line = ("%s -n '__fish_seen_subcommand_from %s' -xa '%s'")
+         :format(prefix, table.concat(self._aliases, " "), self._parent:_get_commands())
+      table.insert(buf, line)
    end
 
    for _, option in ipairs(self._options) do

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1111,8 +1111,8 @@ function Parser:add_complete(value)
 end
 
 local function get_short_description(element)
-   local short = element._description:match("^(.-)%.%s")
-   return short or element._description:match("^(.-)%.?$")
+   local short = element:_get_description():match("^(.-)%.%s")
+   return short or element:_get_description():match("^(.-)%.?$")
 end
 
 local function get_options(parser)


### PR DESCRIPTION
The `--completion <shell>` option outputs a completion script and can be enabled with `parser:add_complete()`.

#### fish

[`complete` documentation](https://fishshell.com/docs/current/commands.html#complete)

Options:
```fish
complete -c prog [-n '__fish_seen_subcommand_from subcommand'] -s short -l long ... \
    [-r | -xa 'choice1 choice2' ...] -d 'description'
```
- `__fish_seen_subcommand_from` is used if the option applies to to a subcommand
- `-r` is used if an argument is required
- `-xa choices` is used if the argument has a set of choices

Commands:
```fish
complete -c prog -n '__fish_use_subcommand' -xa 'cmd' -d 'description'
```
- Completes cmd if a non-option argument has not been given

Argument for help command:
```fish
complete -c prog -n '__fish_seen_subcommand_from help' -xa 'cmd'
```

Use `prog --completion fish | source` to activate completions.

#### bash

<details>
<summary>Example completion script</summary>

```bash
_comptest() {
    local cur prev cmd opts arg
    cur="${COMP_WORDS[COMP_CWORD]}"  # word being completed
    prev="${COMP_WORDS[COMP_CWORD-1]}"
    cmd="comptest"
    opts="-h --help --completion -f --file"

    case "$prev" in
        --completion)
            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
            return 0
            ;;
        -f|--file)
            COMPREPLY=($(compgen -f "$cur"))  # complete files if option requires an argument
            return 0
            ;;
    esac

    # check for subcommand
    for arg in ${COMP_WORDS[@]:1}
    do
        case "$arg" in
            install|i)
                cmd="install"
                break
                ;;
        esac
    done

    case "$cmd" in
        comptest)  # main or help command: complete subcommands
            COMPREPLY=($(compgen -W "help install i" -- "$cur"))
            ;;
        install)
            case "$prev" in
                --deps-mode)
                    COMPREPLY=($(compgen -W "all one order none" -- "$cur"))
                    return 0
                    ;;
            esac

            opts="$opts -h --help --deps-mode --no-doc"  # subcommand options
            ;;
    esac

    if [[ "$cur" = -* ]]
    then
        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
    fi
}

complete -F _comptest -o bashdefault -o default comptest
```
</details>

Enable completions with `source <(./comptest --completion bash)`.