### PR TITLE
Make add_help_command a Parser method

### DIFF
--- a/docsrc/misc.rst
+++ b/docsrc/misc.rst
@@ -31,13 +31,13 @@ If the property ``add_help`` of a parser is set to ``false``, no help option wil
 Help command
 ------------
 
-If the property ``add_help_command`` of a parser is set to ``true``, a help command will be added to it. A string or table value can be used to configure the command.
+A help command can be added to the parser using the ``:add_help_command([value])`` method. It accepts an optional string or table value which is used to configure the command.
 
 .. code-block:: lua
    :linenos:
 
    local parser = argparse()
-      :add_help_command(true)
+      :add_help_command()
    parser:command "install"
       :description "Install a rock."
 
@@ -173,7 +173,6 @@ Property                    Type
 ``require_command``         Boolean
 ``handle_options``          Boolean
 ``add_help``                Boolean or string or table
-``add_help_command``        Boolean or string or table
 ``command_target``          String
 ``usage_max_width``         Number
 ``usage_margin``            Number

--- a/spec/script.lua
+++ b/spec/script.lua
@@ -1,9 +1,10 @@
 #!/usr/bin/env lua
+
 local Parser = require "argparse"
 
 local parser = Parser()
    :description "A testing program."
-   :add_help_command(true)
+   :add_help_command()
    :require_command(false)
 
 parser:argument "input"

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -227,49 +227,6 @@ local add_help = {"add_help", function(self, value)
    end
 end}
 
-local add_help_command = {"add_help_command", function(self, value)
-   typecheck("add_help_command", {"boolean", "string", "table"}, value)
-
-   if self._help_command_idx then
-      table.remove(self._commands, self._help_command_idx)
-      self._help_command_idx = nil
-   end
-
-   if value then
-      local help = self:command()
-         :description "Show help for commands."
-      help:argument "command"
-         :description "The command to show help for."
-         :args "?"
-         :action(function(_, _, cmd)
-            if not cmd then
-               print(self:get_help())
-               os.exit(0)
-            else
-               for _, command in ipairs(self._commands) do
-                  for _, alias in ipairs(command._aliases) do
-                     if alias == cmd then
-                        print(command:get_help())
-                        os.exit(0)
-                     end
-                  end
-               end
-            end
-            help:error(("unknown command '%s'"):format(cmd))
-         end)
-
-      if value ~= true then
-         help = help(value)
-      end
-
-      if not help._name then
-         help "help"
-      end
-
-      self._help_command_idx = #self._commands
-   end
-end}
-
 local Parser = class({
    _arguments = {},
    _options = {},
@@ -295,8 +252,7 @@ local Parser = class({
    typechecked("help_usage_margin", "number"),
    typechecked("help_description_margin", "number"),
    typechecked("help_max_width", "number"),
-   add_help,
-   add_help_command
+   add_help
 })
 
 local Command = class({
@@ -1085,6 +1041,45 @@ function Parser:get_help()
    end
 
    return table.concat(blocks, "\n\n")
+end
+
+function Parser:add_help_command(value)
+   if value then
+      assert(type(value) == "string" or type(value) == "table",
+         ("bad argument #1 to 'add_help_command' (string or table expected, got %s)"):format(type(value)))
+   end
+
+   local help = self:command()
+      :description "Show help for commands."
+   help:argument "command"
+      :description "The command to show help for."
+      :args "?"
+      :action(function(_, _, cmd)
+         if not cmd then
+            print(self:get_help())
+            os.exit(0)
+         else
+            for _, command in ipairs(self._commands) do
+               for _, alias in ipairs(command._aliases) do
+                  if alias == cmd then
+                     print(command:get_help())
+                     os.exit(0)
+                  end
+               end
+            end
+         end
+         help:error(("unknown command '%s'"):format(cmd))
+      end)
+
+   if value then
+      help = help(value)
+   end
+
+   if not help._name then
+      help "help"
+   end
+
+   return self
 end
 
 local function get_tip(context, wrong_name)


### PR DESCRIPTION
I decided this would make more sense because the value passed to `add_help_command` doesn't need to be saved in a parser property and the value is optional.