### PR TITLE
Add summary command property

### DIFF
--- a/docsrc/commands.rst
+++ b/docsrc/commands.rst
@@ -140,3 +140,43 @@ This can be changed using ``require_command`` property.
    local parser = argparse()
       :require_command(false)
    parser:command "install"
+
+Command summaries
+-----------------
+
+The description for commands shown in the parent parser help message can be set
+with the ``summary`` property.
+
+.. code-block:: lua
+   :linenos:
+
+   parser:command "install"
+      :summary "Install a rock."
+      :description "A long description for the install command."
+
+.. code-block:: none
+
+   $ lua script.lua --help
+
+.. code-block:: none
+
+   Usage: script.lua [-h] <command> ...
+
+   Options:
+      -h, --help            Show this help message and exit.
+
+   Commands:
+      install               Install a rock.
+
+.. code-block:: none
+
+   $ lua script.lua install --help
+
+.. code-block:: none
+
+   Usage: script.lua install [-h]
+
+   A long description for the install command.
+
+   Options:
+      -h, --help            Show this help message and exit.

--- a/docsrc/misc.rst
+++ b/docsrc/misc.rst
@@ -201,6 +201,7 @@ Other properties:
 =========================== ==========================
 Property                    Type
 =========================== ==========================
+``summary``                 String
 ``target``                  String
 ``usage``                   String
 ``help``                    String

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -306,6 +306,7 @@ local Command = class({
    multiname,
    typechecked("description", "string"),
    typechecked("epilog", "string"),
+   typechecked("summary", "string"),
    typechecked("target", "string"),
    typechecked("usage", "string"),
    typechecked("help", "string"),
@@ -589,7 +590,7 @@ function Argument:_get_description()
 end
 
 function Command:_get_description()
-   return self._description or ""
+   return self._summary or self._description or ""
 end
 
 function Option:_get_usage()


### PR DESCRIPTION
Allows setting the description shown in the main help separately so that a longer description can be used for the command help.