### PR TITLE
Fix bash completion error

### DIFF
--- a/spec/completion_spec.lua
+++ b/spec/completion_spec.lua
@@ -31,7 +31,7 @@ _comptest() {
             return 0
             ;;
         -f|--files)
-            COMPREPLY=($(compgen -f "$cur"))
+            COMPREPLY=($(compgen -f -- "$cur"))
             return 0
             ;;
     esac

--- a/src/argparse.lua
+++ b/src/argparse.lua
@@ -1218,7 +1218,7 @@ function Parser:_bash_option_args(buf, indent)
          if option._choices then
             compreply = 'COMPREPLY=($(compgen -W "' .. table.concat(option._choices, " ") .. '" -- "$cur"))'
          else
-            compreply = 'COMPREPLY=($(compgen -f "$cur"))'
+            compreply = 'COMPREPLY=($(compgen -f -- "$cur"))'
          end
          table.insert(opts, (" "):rep(indent + 4) .. table.concat(option._aliases, "|") .. ")")
          table.insert(opts, (" "):rep(indent + 8) .. compreply)


### PR DESCRIPTION
Fixes this error:
```
$ ./comptest --files --g<TAB>bash: compgen: --: invalid option
compgen: usage: compgen [-abcdefgjksuv] [-o option] [-A action] [-G globpat] [-W wordlist]  [-F function] [-C command] [-X filterpat] [-P prefix] [-S suffix] [word]
```