### PR TITLE
Add hidden command and option aliases

### DIFF
--- a/docsrc/messages.rst
+++ b/docsrc/messages.rst
@@ -39,6 +39,41 @@ it is not included into help and usage messages, but otherwise works normally.
       deprecated_option = "value"
    }
 
+Hiding option and command aliases
+---------------------------------
+
+Hidden aliases can be added to an option or command by setting the
+``hidden_name`` property. Its value is interpreted in the same way as the
+``name`` property.
+
+.. code-block:: lua
+   :linenos:
+
+   parser:option "--server"
+      :hidden_name "--from"
+
+.. code-block:: none
+
+   $ lua script.lua --help
+
+.. code-block:: none
+
+   Usage: script.lua [-h] [--server <server>]
+
+   Options:
+      -h, --help            Show this help message and exit.
+      --server <server>
+
+.. code-block:: none
+
+   $ lua script.lua --server foo
+   $ lua script.lua --from foo
+
+.. code-block:: lua
+
+   {
+      server = "foo"
+   }
 
 Setting argument placeholder
 ----------------------------

--- a/docsrc/misc.rst
+++ b/docsrc/misc.rst
@@ -200,6 +200,7 @@ Other properties:
 =========================== ==========================
 Property                    Type
 =========================== ==========================
+``hidden_name``             String
 ``summary``                 String
 ``target``                  String
 ``usage``                   String
@@ -269,6 +270,7 @@ Other properties:
 =================== ==================
 Property            Type
 =================== ==================
+``hidden_name``     String
 ``target``          String
 ``defmode``         String
 ``show_default``    Boolean

--- a/spec/help_spec.lua
+++ b/spec/help_spec.lua
@@ -311,6 +311,24 @@ Commands:
 Usage: foo]], parser:get_help())
    end)
 
+   it("does not mention hidden option and command aliases", function()
+      local parser = Parser "foo"
+      parser:option "--server"
+         :hidden_name "--from"
+      parser:command "newname"
+         :hidden_name "oldname"
+
+      assert.equal([[
+Usage: foo [-h] [--server <server>] <command> ...
+
+Options:
+   -h, --help            Show this help message and exit.
+   --server <server>
+
+Commands:
+   newname]], parser:get_help())
+   end)
+
    it("supports grouping options", function()
       local parser = Parser "foo"
          :add_help(false)

--- a/spec/options_spec.lua
+++ b/spec/options_spec.lua
@@ -57,14 +57,14 @@ describe("tests related to options", function()
          assert.same({server = {"foo", "bar"}}, args)
       end)
 
-      it("handles short option correclty", function()
+      it("handles short option correctly", function()
          local parser = Parser()
          parser:option "-s" "--server"
          local args = parser:parse({"-s", "foo"})
          assert.same({server = "foo"}, args)
       end)
 
-      it("handles flag correclty", function()
+      it("handles flag correctly", function()
          local parser = Parser()
          parser:flag "-q" "--quiet"
          local args = parser:parse({"--quiet"})
@@ -73,7 +73,7 @@ describe("tests related to options", function()
          assert.same({}, args)
       end)
 
-      it("handles combined flags correclty", function()
+      it("handles combined flags correctly", function()
          local parser = Parser()
          parser:flag "-q" "--quiet"
          parser:flag "-f" "--fast"
@@ -88,7 +88,7 @@ describe("tests related to options", function()
          assert.same({server = "foo"}, args)
       end)
 
-      it("handles flags combined with short option correclty", function()
+      it("handles flags combined with short option correctly", function()
          local parser = Parser()
          parser:flag "-q" "--quiet"
          parser:option "-s" "--server"
@@ -144,6 +144,14 @@ describe("tests related to options", function()
             :target "tail"
          local args = parser:parse{"--", "foo", "--unrelated", "bar"}
          assert.same({tail = {"foo", "--unrelated", "bar"}}, args)
+      end)
+
+      it("handles hidden option aliases", function()
+         local parser = Parser()
+         parser:option "--server"
+            :hidden_name "--from"
+         local args = parser:parse{"--from", "foo"}
+         assert.same({server = "foo"}, args)
       end)
 
       describe("Special chars set", function()


### PR DESCRIPTION
Adds `:hidden_name` for commands and options which is the same as `:name` except the aliases are not shown in help messages. Can be used for deprecated/alternate option/command names.