### PR TITLE
rockspec: bump max lua version

### DIFF
--- a/argparse-scm-2.rockspec
+++ b/argparse-scm-2.rockspec
@@ -10,7 +10,7 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, < 5.4"
+   "lua >= 5.1, < 5.5"
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
We don't seem to require any changes for 5.4 support

Closes #15